### PR TITLE
feat: add multiple configurable options

### DIFF
--- a/resources/views/date-range-picker.blade.php
+++ b/resources/views/date-range-picker.blade.php
@@ -71,8 +71,12 @@
                 window.$(function () {
                     window.$('input[name="daterange"]').daterangepicker({
                         alwaysShowCalendars: {{$isAlwaysShowCalender()? 'true' : 'false'}},
+                        autoApply: {{ $getAutoApplyOption() }},
+                        linkedCalendars: {{ $getLinkedCalendarsOption() }},
                         {!! $getMaxDate() !== null?"maxDate: moment('".$getMaxDate()."'),":"" !!}
                         {!! $getMinDate() !== null?"minDate: moment('".$getMinDate()."'),":"" !!}
+                        timePicker: {{ $getTimePickerOption() }},
+                        timePickerIncrement: {{ $getTimePickerIncrementOption() }},
                         locale: {
                             format: "{{$getDisplayFormat()}}",
                             separator: " - ",
@@ -120,7 +124,7 @@
                             '{!!__('filament-daterangepicker-filter::message.last_year')!!}'    : [moment().subtract(1, 'year').startOf('year'), moment().subtract(1, 'year').endOf('year')]
                         }
                     }, function (start, end, label) {
-                    @this.set('{!!$getStatePath()!!}', start.format('DD/MM/YYYY') + ' - ' + end.format('DD/MM/YYYY'));
+                    @this.set('{!!$getStatePath()!!}', start.format('{!! $getDisplayFormat() !!}') + ' - ' + end.format('{!! $getDisplayFormat() !!}'));
                     }).val(state);
                 });
 

--- a/src/Fields/DateRangePicker.php
+++ b/src/Fields/DateRangePicker.php
@@ -24,9 +24,13 @@ class DateRangePicker extends Forms\Components\Field
     protected array $extraTriggerAttributes = [];
     protected int | null $firstDayOfWeek = null;
     protected string | Closure | null $format = null;
-    protected bool | Closure $isWithoutDate = false;
-    protected bool | Closure $isWithoutSeconds = false;
-    protected bool | Closure $isWithoutTime = false;
+    // protected bool | Closure $isWithoutDate = false;
+    // protected bool | Closure $isWithoutSeconds = false;
+    // protected bool | Closure $isWithoutTime = false;
+    protected bool $timePicker = false;
+    protected int $timePickerIncrement = 30;
+    protected bool $autoApply = false;
+    protected bool $linkedCalendars = false;
     protected bool | Closure $shouldCloseOnDateSelection = false;
     protected CarbonInterface | string | Closure | null $maxDate = null;
     protected CarbonInterface | string | Closure | null $minDate = null;
@@ -324,4 +328,53 @@ class DateRangePicker extends Forms\Components\Field
         return $this->alwaysShowCalender;
     }
 
+    public function setTimePickerOption(bool $condition = true): static
+    {
+        $this->timePicker = $condition;
+
+        return $this;
+    }
+
+    public function getTimePickerOption(): string
+    {
+        return $this->timePicker ? 'true' : 'false';
+    }
+
+    public function setTimePickerIncrementOption(int $increment = 1): static
+    {
+        $this->timePickerIncrement = $increment;
+
+        return $this;
+    }
+
+    public function getTimePickerIncrementOption(): int
+    {
+        return $this->timePickerIncrement;
+    }
+
+
+    public function setAutoApplyOption(bool $condition = true): static
+    {
+        $this->autoApply = $condition;
+
+        return $this;
+    }
+
+    // NOTE: auto apply will not be enabled by daterangepicker.js if timePicker is set
+    public function getAutoApplyOption(): string
+    {
+        return $this->autoApply ? 'true' : 'false';
+    }
+
+    public function setLinkedCalendarsOption(bool $condition = true): static
+    {
+        $this->linkedCalendars = $condition;
+
+        return $this;
+    }
+
+    public function getLinkedCalendarsOption(): string
+    {
+        return $this->linkedCalendars ? 'true' : 'false';
+    }
 }


### PR DESCRIPTION
- new options: autoApply, linkedCalendars, timerPicker, timerPickerIncrement
- fix the display format in js when the time is shown, e.g. `->displayFormat('YYYY-MM-DD(HH:mm)')`


Sample usage
```php
                DateRangePicker::make('StartAndEndDate')
                    ->setTimePickerOption(true)
                    ->setTimePickerIncrementOption(2)
                    ->setLinkedCalendarsOption(true)
                    ->label('Event Date (start to end)')
                    ->displayFormat('YYYY-MM-DD(HH:mm)')
                    ->formatStateUsing(function ($record) {
                        $start = Carbon::parse($record['StartTime']);
                        $end = Carbon::parse($record['EndTime']);
                        return $start->format('Y-m-d(H:i)') . " - " . $end->format('Y-m-d(H:i)');
                    }),
```