### PR TITLE
Fix issue with month and year select dropdowns while in dark mode

### DIFF
--- a/resources/css/filament-daterangepicker.css
+++ b/resources/css/filament-daterangepicker.css
@@ -36,13 +36,13 @@
     @apply bg-primary-500 text-white;
 }
 
-.daterangepicker .hourselect, .daterangepicker .minuteselect, .daterangepicker .secondselect, .daterangepicker .ampmselect {
+.daterangepicker .hourselect, .daterangepicker .minuteselect, .daterangepicker .secondselect, .daterangepicker .ampmselect, .daterangepicker .monthselect, .daterangepicker .yearselect {
     @apply dark:bg-transparent;
     @apply dark:border-gray-700;
     @apply bg-white;
 }
 
-.daterangepicker .hourselect > option, .daterangepicker .minuteselect > option, .daterangepicker .secondselect > option, .daterangepicker .ampmselect > option {
+.daterangepicker .hourselect > option, .daterangepicker .minuteselect > option, .daterangepicker .secondselect > option, .daterangepicker .ampmselect > option, .daterangepicker .monthselect > option, .daterangepicker .yearselect > option {
     @apply dark:bg-gray-800;
     @apply dark:border-gray-700;
     @apply bg-white;


### PR DESCRIPTION
Fix the background for the month and year select dropdowns when in dark mode. Without this the text color is the same as the background except for the currently selected entry:

![Screenshot 2025-03-06 113448](https://github.com/user-attachments/assets/fdbf9892-28d6-49ce-9083-1cdb4b83a8a1)

With this change:
![Screenshot 2025-03-06 113545](https://github.com/user-attachments/assets/bfb7209a-bf90-4f4e-82d3-9f0d9db7ea45)

I'm not 100% sure that it's the correct fix, but it works for my installation!