### PR TITLE
Use subMonthNoOverflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,8 @@ Specify the minimum and maximum dates for the calendar. The following example wi
 use Malzariey\FilamentDaterangepickerFilter\Filters\DateRangeFilter;
 use Malzariey\FilamentDaterangepickerFilter\Fields\DateRangePicker;
 
-DateRangeFilter::make('created_at')->minDate(Carbon::now()->subMonth())->maxDate(Carbon::now()->addMonth())
-DateRangePicker::make('created_at')->minDate(Carbon::now()->subMonth())->maxDate(Carbon::now()->addMonth())
+DateRangeFilter::make('created_at')->minDate(Carbon::now()->subMonthNoOverflow())->maxDate(Carbon::now()->addMonth())
+DateRangePicker::make('created_at')->minDate(Carbon::now()->subMonthNoOverflow())->maxDate(Carbon::now()->addMonth())
 ````
 
 #### First Day of Week

--- a/src/Concerns/HasRangePicker.php
+++ b/src/Concerns/HasRangePicker.php
@@ -421,8 +421,8 @@ trait HasRangePicker
 
     public function defaultLastMonth($enforceIfNull = false): static
     {
-        $this->startDate = $this->now()->subMonth()->startOfMonth();
-        $this->endDate = $this->now()->subMonth()->endOfMonth();
+        $this->startDate = $this->now()->subMonthNoOverflow()->startOfMonth();
+        $this->endDate = $this->now()->subMonthNoOverflow()->endOfMonth();
 
         $this->processDefault($enforceIfNull);
 

--- a/src/Fields/DateRangePicker.php
+++ b/src/Fields/DateRangePicker.php
@@ -229,7 +229,7 @@ class DateRangePicker extends Field implements HasAffixActions
                 __('filament-daterangepicker-filter::message.last_7_days') => [$this->now()->subDays(6), $this->now()],
                 __('filament-daterangepicker-filter::message.last_30_days') => [$this->now()->subDays(29), $this->now()],
                 __('filament-daterangepicker-filter::message.this_month') => [$this->now()->startOfMonth(), $this->now()->endOfMonth()],
-                __('filament-daterangepicker-filter::message.last_month') => [$this->now()->subMonth()->startOfMonth(), $this->now()->subMonth()->endOfMonth()],
+                __('filament-daterangepicker-filter::message.last_month') => [$this->now()->subMonthNoOverflow()->startOfMonth(), $this->now()->subMonthNoOverflow()->endOfMonth()],
                 __('filament-daterangepicker-filter::message.this_year') => [$this->now()->startOfYear(), $this->now()->endOfYear()],
                 __('filament-daterangepicker-filter::message.last_year') => [$this->now()->subYear()->startOfYear(), $this->now()->subYear()->endOfYear()],
             ];


### PR DESCRIPTION
The `Last Month` filter does not appear to work under specific circumstances. 

Today on the 31st March Carbons `subMonth()` method is attempting to take 28 days off from the current date, leading to an output of `2025-03-03 00:00:00` rather than `2025-02-28 00:00:00` as expected. 

![Screenshot 2025-03-31 at 14 02 32](https://github.com/user-attachments/assets/be7ee9d1-86d6-43f1-b57a-b6e5e618beec)

By replacing `subMonth()` with `subMonthNoOverflow()` then the subtraction will ignore the additional days past the number that exists in the previous month (29th, 30th, 31st) and correctly sets the previous month.

![Screenshot 2025-03-31 at 14 16 37](https://github.com/user-attachments/assets/7801c739-5a14-4a7c-a674-f871bda15c35)


