### PR TITLE
Revert "fix picker not opening in spa mode bug"

### DIFF
--- a/resources/views/date-range-picker.blade.php
+++ b/resources/views/date-range-picker.blade.php
@@ -16,10 +16,10 @@
     :field="$field"
 >
     <div
+        x-ignore
         @if (\Filament\Support\Facades\FilamentView::hasSpaMode())
             ax-load="visible || event (ax-modal-opened)"
         @else
-            x-ignore
             ax-load
         @endif
 


### PR DESCRIPTION
Reverts malzariey/filament-daterangepicker-filter#158

Assets not being loaded in SPA mode

