### PR TITLE
made the readOnly property defined by the user instead of having it by default.

### DIFF
--- a/resources/views/date-range-picker.blade.php
+++ b/resources/views/date-range-picker.blade.php
@@ -140,7 +140,7 @@
                                 'placeholder' => $getPlaceholder(),
                                 'tabindex' => $isAutofocused() ? 0 : -1,
                                 'required' => $isRequired(),
-                                'readonly' => true,
+                                'readonly' => $isReadOnly(),
                                 'type' => 'text',
                             ], escape: false)"
                     />

--- a/src/Fields/DateRangePicker.php
+++ b/src/Fields/DateRangePicker.php
@@ -10,6 +10,7 @@ use Filament\Forms\Components\Concerns\{HasAffixes, HasExtraInputAttributes, Has
 use Filament\Forms\Components\Contracts\HasAffixActions;
 use Filament\Forms\Components\Field;
 use Filament\Support\Concerns\HasExtraAlpineAttributes;
+use Filament\Forms\Components\Concerns\CanBeReadOnly;
 use Illuminate\View\ComponentAttributeBag;
 use JetBrains\PhpStorm\Deprecated;
 use Malzariey\FilamentDaterangepickerFilter\Concerns\HasRangePicker;
@@ -21,6 +22,7 @@ class DateRangePicker extends Field implements HasAffixActions
     use HasAffixes;
     use HasExtraInputAttributes;
     use HasExtraAlpineAttributes;
+    use CanBeReadOnly;
 
     protected string $view = 'filament-daterangepicker-filter::date-range-picker';
     protected array $extraTriggerAttributes = [];

--- a/src/Filters/DateRangeFilter.php
+++ b/src/Filters/DateRangeFilter.php
@@ -8,10 +8,12 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Carbon;
 use Malzariey\FilamentDaterangepickerFilter\Concerns\HasRangePicker;
 use Malzariey\FilamentDaterangepickerFilter\Fields\DateRangePicker;
+use Filament\Forms\Components\Concerns\CanBeReadOnly;
 
 class DateRangeFilter extends BaseFilter
 {
     use HasRangePicker;
+    use CanBeReadOnly;
 
     protected string $column;
 


### PR DESCRIPTION
## The current situation
The picker is disabled by default which does not fit in the design of the forms, the users thinks it does not work or is not usable especialy because of the cursor not allowed that apears on hover.

## The proposed solution
Give back the readonly option control to the user.