### PR TITLE
Fix date format inconsistency between display and filter processing

### DIFF
--- a/src/Concerns/HasRangePicker.php
+++ b/src/Concerns/HasRangePicker.php
@@ -486,6 +486,31 @@ trait HasRangePicker
         return $this->evaluate($this->timePicker);
     }
 
+    function jsDateFormatToPhp($jsFormat) {
+        $patterns = [
+            '/\bYYYY\b/' => 'Y',
+            '/\bYY\b/' => 'y',
+            '/\bMMMM\b/' => 'F',
+            '/\bMMM\b/' => 'M',
+            '/\bMM\b/' => 'm',
+            '/\bM\b/' => 'n',
+            '/\bDD\b/' => 'd',
+            '/\bD\b/' => 'j',
+            '/\bHH\b/' => 'H',
+            '/\bH\b/' => 'G',
+            '/\bhh\b/' => 'h',
+            '/\bh\b/' => 'g',
+            '/\bmm\b/' => 'i',
+            '/\bss\b/' => 's',
+        ];
+
+        return preg_replace(
+            array_keys($patterns),
+            array_values($patterns),
+            $jsFormat
+        );
+    }
+
     #[Deprecated(since: '2.5.1')]
     public function getTimePickerOption(): bool
     {

--- a/src/Filters/DateRangeFilter.php
+++ b/src/Filters/DateRangeFilter.php
@@ -79,13 +79,13 @@ class DateRangeFilter extends BaseFilter
 
             if ($this->timePicker) {
                 $dates = [
-                    Carbon::createFromFormat($this->getFormat(), $from, $this->getTimezone())->timezone($this->getSystemTimezone()),
-                    Carbon::createFromFormat($this->getFormat(), $to, $this->getTimezone())->timezone($this->getSystemTimezone())
+                    Carbon::createFromFormat($this->jsDateFormatToPhp($this->getDisplayFormat()), $from, $this->getTimezone())->timezone($this->getSystemTimezone()),
+                    Carbon::createFromFormat($this->jsDateFormatToPhp($this->getDisplayFormat()), $to, $this->getTimezone())->timezone($this->getSystemTimezone())
                 ];
             } else {
                 $dates = [
-                    Carbon::createFromFormat($this->getFormat(), $from, $this->getTimezone())->startOfDay()->timezone($this->getSystemTimezone()),
-                    Carbon::createFromFormat($this->getFormat(), $to, $this->getTimezone())->endOfDay()->timezone($this->getSystemTimezone()),
+                    Carbon::createFromFormat($this->jsDateFormatToPhp($this->getDisplayFormat()), $from, $this->getTimezone())->startOfDay()->timezone($this->getSystemTimezone()),
+                    Carbon::createFromFormat($this->jsDateFormatToPhp($this->getDisplayFormat()), $to, $this->getTimezone())->endOfDay()->timezone($this->getSystemTimezone()),
                 ];
             }
 


### PR DESCRIPTION
When using ->displayFormat(), the system expects a JavaScript date format (e.g., DD.MM.YYYY), but when processing filter changes, it expects a PHP date format (e.g., d.m.Y). This inconsistency causes filter functionality to fail when custom date formats are applied.
Solution

Added a helper function to convert JavaScript date format strings to PHP date format strings
Applied the conversion when processing filter changes to ensure format consistency

Changes

Implemented jsDateFormatToPhp() function for format conversion
Updated filter change handler to use the converted format

This ensures that date filters work correctly regardless of the display format specified.