### PR TITLE
refactor: Filament timezone as default timezone

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ DateRangeFilter::make('created_at'),
 ### Options
 
 #### Timezone
-Set the picker timezone, defaults to the project timezone. Example setting timezone to 'UTC'.
+Set the picker timezone, defaults to Filament timezone. Example setting timezone to 'UTC'.
 
 ```php
 use Malzariey\FilamentDaterangepickerFilter\Filters\DateRangeFilter;

--- a/src/Concerns/HasRangePicker.php
+++ b/src/Concerns/HasRangePicker.php
@@ -4,6 +4,7 @@ namespace Malzariey\FilamentDaterangepickerFilter\Concerns;
 
 use Carbon\CarbonInterface;
 use Closure;
+use Filament\Support\Facades\FilamentTimezone;
 use JetBrains\PhpStorm\Deprecated;
 use Malzariey\FilamentDaterangepickerFilter\Enums\DropDirection;
 use Malzariey\FilamentDaterangepickerFilter\Enums\OpenDirection;
@@ -375,7 +376,7 @@ trait HasRangePicker
 
     public function getSystemTimezone(): string
     {
-        return config('app.timezone');
+        return FilamentTimezone::get();
     }
 
     public function defaultYesterday($enforceIfNull = false): static


### PR DESCRIPTION
All Filament date fields' timezone default to Filament timezone, I suppose that this should be the default behavior for this great package also to contain consistency.