### PR TITLE
Add Laravel 13 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "filament/filament": "^3.0",
         "spatie/laravel-package-tools": "^1.16.4",
-        "illuminate/contracts": "^8.0|^9.0|^10.0|^11.0|^11.0|^12.0"
+        "illuminate/contracts": "^8.0|^9.0|^10.0|^11.0|^11.0|^12.0|^13.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "filament/filament": "^3.0",
         "spatie/laravel-package-tools": "^1.16.4",
-        "illuminate/contracts": "^8.0|^9.0|^10.0|^11.0|^11.0|^12.0|^13.0"
+        "illuminate/contracts": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Laravel 13 (released 2026-03-17) is stable.

This targets the `x3` (Filament v3) line and only widens the `illuminate/contracts` version constraint (adds `|^13.0`); the package code uses none of the Laravel 13 breaking changes.

Filament v3 already supports Laravel 13 (`filament/support` on `3.x` allows `illuminate/* ^13.0`), so this package's constraint on the 3.x line is the only remaining blocker for using it on Laravel 13.

Verified in production: the package runs unchanged on Laravel 13.22, only the constraint was blocking the upgrade.

No code changes, tests unaffected.